### PR TITLE
Make fcr = 128 - T for CCSDS, i.e. 112 for 255,223 and 120 for 255,239

### DIFF
--- a/c++/ezpwd/rs
+++ b/c++/ezpwd/rs
@@ -93,7 +93,7 @@ namespace ezpwd {
     template < size_t PAYLOAD > struct RS<65535, PAYLOAD> : public __RS( RS, uint16_t, 65535, PAYLOAD, 0x1100b,	 1,  1 );
     
     template < size_t SYMBOLS, size_t PAYLOAD > struct RS_CCSDS;
-    template < size_t PAYLOAD > struct RS_CCSDS<255, PAYLOAD> : public __RS( RS_CCSDS, uint8_t, 255, PAYLOAD, 0x187, 112, 11 );
+    template < size_t PAYLOAD > struct RS_CCSDS<255, PAYLOAD> : public __RS( RS_CCSDS, uint8_t, 255, PAYLOAD, 0x187, 128 - (255-PAYLOAD) / 2, 11 );
 
 
     // 


### PR DESCRIPTION
CCSDS allows both 255,223 and 255,239: the fcr needs to be 112 for 255,223 but 120 for the 255,239 case. 