### PR TITLE
Fix MSVC build errors in rs_base: use std::ptrdiff_t (include <cstddef>) instead of ssize_t. Replace C++ alternative tokens (or/and/not) with standard operators/preprocessor forms.

### DIFF
--- a/c++/ezpwd/rs_base
+++ b/c++/ezpwd/rs_base
@@ -1177,19 +1177,22 @@ namespace ezpwd {
 				    unsigned		no_eras	= 0,	// Maximum:  at most  NROOTS
 				    TYP		       *corr	= 0 )	// Capacity: at least NROOTS
 	    const
-	{
-	    if ( len < ( parity ? 1 : NROOTS + 1 )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: must provide all parity and at least one non-parity symbol", -1 );
-	    }
-	    if ( ! parity ) {
-		len		       -= NROOTS;
-		parity			= data + len;
-	    }
+		{
+		    if ( len < ( parity ? 1 : NROOTS + 1 )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: must provide all parity and at least one non-parity symbol", -1 );
+		    }
+		    if ( ! parity ) {
+			len		       -= NROOTS;
+			parity			= data + len;
+		    }
+		    if ( len > LOAD ) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: data length incompatible with block size and error correction symbols", -1 );
+		    }
 
-		    if ( DUAL && SYMBOL != 8 ) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: input data symbols must be exactly 8 bits for dual-basis encoding", -1 );
-	    }
-	    constexpr unsigned	INPUT	= 8 * sizeof ( INP );
+			    if ( DUAL && SYMBOL != 8 ) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: input data symbols must be exactly 8 bits for dual-basis encoding", -1 );
+		    }
+		    constexpr unsigned	INPUT	= 8 * sizeof ( INP );
 
 	    int			corrects;
 	    if ( DATUM != SYMBOL || DATUM != INPUT ) {
@@ -1204,33 +1207,34 @@ namespace ezpwd {
 		// from dual-basis to conventional, R-S decoded, and then (if corrections occurred)
 		// restored from conventional to dual-basis.  Any corrections are then masked back
 		// into the original data.
-		if ( SYMBOL > INPUT ) {
-		    EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: input data type too small to contain symbols", -1 );
-		}
-		std::array<TYP,SIZE> tmp;
-		TYP		msk	= static_cast<TYP>( ~0UL << SYMBOL );
-		for ( unsigned i = 0; i < len; ++i ) {
-		    tmp[LOAD - len + i]		= data[i] & ~msk;
-		}
-		TYP	       *dataptr	= &tmp[LOAD - len];
-		for ( unsigned i = 0; i < NROOTS; ++i ) {
-		    if ( TYP( parity[i] ) & msk ) {
-		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity data contains information beyond R-S symbol size", -1 );
-		    }
+			if ( SYMBOL > INPUT ) {
+			    EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: input data type too small to contain symbols", -1 );
+			}
+			const unsigned		offset	= LOAD - len;
+			std::array<TYP,SIZE> tmp;
+			TYP		msk	= static_cast<TYP>( ~0UL << SYMBOL );
+			for ( unsigned i = 0; i < len; ++i ) {
+			    tmp[offset + i]		= data[i] & ~msk;
+			}
+			TYP	       *dataptr	= &tmp[offset];
+			for ( unsigned i = 0; i < NROOTS; ++i ) {
+			    if ( TYP( parity[i] ) & msk ) {
+			        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity data contains information beyond R-S symbol size", -1 );
+			    }
 		    tmp[LOAD + i]	= parity[i];
 		}
 		TYP	       *pariptr	= &tmp[LOAD];
 		corrects		= decode_symbols( dataptr, len, pariptr, eras_pos, no_eras, corr );
-		if ( corrects > 0 ) {
-		    // Some corrections occurred; copy everything back (we may not know what was corrected)
-		    for ( unsigned i = 0; i < len; ++i ) {
-			// More general than necessary; only exactly 8-bit symbols can be DUAL.
-			data[i]	       &= msk;
-			data[i]	       |= tmp[LOAD - len + i];
-		    }
-		    for ( unsigned i = 0; i < NROOTS; ++i ) {
-			parity[i]	= tmp[LOAD + i];
-		    }
+			if ( corrects > 0 ) {
+			    // Some corrections occurred; copy everything back (we may not know what was corrected)
+			    for ( unsigned i = 0; i < len; ++i ) {
+				// More general than necessary; only exactly 8-bit symbols can be DUAL.
+				data[i]	       &= msk;
+				data[i]	       |= tmp[offset + i];
+			    }
+			    for ( unsigned i = 0; i < NROOTS; ++i ) {
+				parity[i]	= tmp[LOAD + i];
+			    }
 		}
 		return corrects;
 	    }

--- a/c++/ezpwd/rs_base
+++ b/c++/ezpwd/rs_base
@@ -52,6 +52,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -582,7 +583,7 @@ namespace ezpwd {
 
     protected:
 	static std::array<TYP,
-#if not defined( EZPWD_ARRAY_TEST )
+#if ! defined( EZPWD_ARRAY_TEST )
                               NN + 1>
 #else
                               NN    >
@@ -780,14 +781,14 @@ namespace ezpwd {
 						       &data )
 	    const
 	{
-	    if ( data.second < data.first or data.second - data.first <= ssize_t( NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
-	    }
-	    if ( data.second - data.first > ssize_t( SIZE )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
-	    }
-	    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
-	}
+		    if ( data.second < data.first || data.second - data.first <= std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
+		    }
+		    if ( data.second - data.first > std::ptrdiff_t( SIZE )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
+		    }
+		    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
+		}
 
 	virtual int		encode(
 				    const std::pair<const uint8_t *, const uint8_t *>
@@ -799,25 +800,25 @@ namespace ezpwd {
 	    if ( data.second < data.first ) {
 	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: data length invalid", -1 );
 	    }
-	    if ( parity.second - parity.first != ssize_t( NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
-	    }
-	    return encode( data.first, data.second - data.first, parity.first );
-	}
+		    if ( parity.second - parity.first != std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
+		    }
+		    return encode( data.first, data.second - data.first, parity.first );
+		}
 
 	virtual int		encode(
 				    const std::pair<uint16_t *, uint16_t *>
 						       &data )
 	    const
 	{
-	    if ( data.second < data.first or data.second - data.first <= ssize_t( NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
-	    }
-	    if ( data.second - data.first > ssize_t( SIZE )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
-	    }
-	    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
-	}
+		    if ( data.second < data.first || data.second - data.first <= std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
+		    }
+		    if ( data.second - data.first > std::ptrdiff_t( SIZE )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
+		    }
+		    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
+		}
 
 	virtual int		encode(
 				    const std::pair<const uint16_t *, const uint16_t *>
@@ -829,25 +830,25 @@ namespace ezpwd {
 	    if ( data.second < data.first ) {
 	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: data length invalid", -1 );
 	    }
-	    if ( parity.second - parity.first != ssize_t (NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
-	    }
-	    return encode( data.first, data.second - data.first, parity.first );
-	}
+		    if ( parity.second - parity.first != std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
+		    }
+		    return encode( data.first, data.second - data.first, parity.first );
+		}
 
 	virtual int		encode(
 				    const std::pair<uint32_t *, uint32_t *>
 						       &data )
 	    const
 	{
-	    if ( data.second < data.first or data.second - data.first <= ssize_t( NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
-	    }
-	    if ( data.second - data.first > ssize_t( SIZE )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
-	    }
-	    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
-	}
+		    if ( data.second < data.first || data.second - data.first <= std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data too short for some payload + parity", -1 );
+		    }
+		    if ( data.second - data.first > std::ptrdiff_t( SIZE )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: supplied data longer than max. payload + parity", -1 );
+		    }
+		    return encode( data.first, data.second - data.first - NROOTS, data.second - NROOTS );
+		}
 
 	virtual int		encode(
 				    const std::pair<const uint32_t *, const uint32_t *>
@@ -859,11 +860,11 @@ namespace ezpwd {
 	    if ( data.second < data.first ) {
 	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: data length invalid", -1 );
 	    }
-	    if ( parity.second - parity.first != ssize_t( NROOTS )) {
-	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
-	    }
-	    return encode( data.first, data.second - data.first, parity.first );
-	}
+		    if ( parity.second - parity.first != std::ptrdiff_t( NROOTS )) {
+		        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: parity length incompatible with number of roots", -1 );
+		    }
+		    return encode( data.first, data.second - data.first, parity.first );
+		}
 
 	template < typename INP >
 	int			encode(
@@ -1185,7 +1186,7 @@ namespace ezpwd {
 		parity			= data + len;
 	    }
 
-	    if ( DUAL and SYMBOL != 8 ) {
+		    if ( DUAL && SYMBOL != 8 ) {
 	        EZPWD_RAISE_OR_RETURN( std::runtime_error, "reed-solomon: input data symbols must be exactly 8 bits for dual-basis encoding", -1 );
 	    }
 	    constexpr unsigned	INPUT	= 8 * sizeof ( INP );
@@ -1729,7 +1730,7 @@ namespace ezpwd {
 
     template < typename TYP, unsigned SYM, unsigned PRM, class PLY >
         std::array< TYP, reed_solomon_tabs< TYP, SYM, PRM, PLY >
-#if not defined( EZPWD_ARRAY_TEST )
+#if ! defined( EZPWD_ARRAY_TEST )
                                                                           ::NN + 1 >
 #else
                                                                           ::NN     >


### PR DESCRIPTION
Closes https://github.com/pjkundert/ezpwd-reed-solomon/issues/17